### PR TITLE
Fix Dashboard deployment

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -3,6 +3,6 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 1.5.4
-appVersion: "0.32.0"
+version: 1.5.5
+appVersion: "0.36.3"
 icon: https://images.crunchbase.com/image/upload/c_pad,h_256,w_256,f_auto,q_auto:eco,dpr_1/kuu5tm1wt09ztp6ctlag

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -1,6 +1,6 @@
 # netbird
 
-![Version: 1.5.4](https://img.shields.io/badge/Version-1.5.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.32.0](https://img.shields.io/badge/AppVersion-0.32.0-informational?style=flat-square)
+![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.3](https://img.shields.io/badge/AppVersion-0.36.3-informational?style=flat-square)
 
 # NetBird Helm Chart
 

--- a/charts/netbird/examples/istio/zitadel/values.yaml
+++ b/charts/netbird/examples/istio/zitadel/values.yaml
@@ -134,7 +134,7 @@ relay:
 dashboard:
   enabled: true
   image:
-    tag: v2.7.0
+    tag: v2.9.0
   env:
     # Endpoints
     NETBIRD_MGMT_API_ENDPOINT: https://netbird.example.com:443

--- a/charts/netbird/examples/nginx-ingress/auth0/values.yaml
+++ b/charts/netbird/examples/nginx-ingress/auth0/values.yaml
@@ -232,7 +232,7 @@ dashboard:
         hosts:
           - netbird-dashboard.example.com
   image:
-    tag: v2.7.0
+    tag: v2.9.0
   env:
     # Endpoints
     NETBIRD_MGMT_API_ENDPOINT: https://netbird.example.com:443

--- a/charts/netbird/examples/nginx-ingress/authentik/values.yaml
+++ b/charts/netbird/examples/nginx-ingress/authentik/values.yaml
@@ -220,7 +220,7 @@ dashboard:
         hosts:
           - netbird-dashboard.example.com
   image:
-    tag: v2.7.0
+    tag: v2.9.0
   env:
     # Endpoints
     NETBIRD_MGMT_API_ENDPOINT: https://netbird.example.com:443

--- a/charts/netbird/examples/nginx-ingress/okta/values.yaml
+++ b/charts/netbird/examples/nginx-ingress/okta/values.yaml
@@ -234,7 +234,7 @@ dashboard:
         hosts:
           - netbird-dashboard.example.com
   image:
-    tag: v2.7.0
+    tag: v2.9.0
   env:
     # Endpoints
     NETBIRD_MGMT_API_ENDPOINT: https://netbird.example.com:443

--- a/charts/netbird/examples/traefik-ingress/authentik/values.yaml
+++ b/charts/netbird/examples/traefik-ingress/authentik/values.yaml
@@ -137,7 +137,7 @@ relay:
 dashboard:
   enabled: true
   image:
-    tag: v2.7.0
+    tag: v2.9.0
   env:
     # Endpoints
     NETBIRD_MGMT_API_ENDPOINT: https://netbird.example.com:443

--- a/charts/netbird/templates/dashboard-deployment.yaml
+++ b/charts/netbird/templates/dashboard-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if and (hasKey .Values.dashboard.podCommand "args") .Values.dashboard.podCommand.args }}
+          {{- if .Values.dashboard.podCommand.args }}
           command: ["/bin/sh", "-c"]
           args:
             {{- range .Values.dashboard.podCommand.args }}

--- a/charts/netbird/templates/dashboard-deployment.yaml
+++ b/charts/netbird/templates/dashboard-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- toYaml .Values.dashboard.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if hasKey .Values.dashboard.podCommand "args" }}
+          {{- if and (hasKey .Values.dashboard.podCommand "args") .Values.dashboard.podCommand.args }}
           command: ["/bin/sh", "-c"]
           args:
             {{- range .Values.dashboard.podCommand.args }}

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -586,7 +586,7 @@ dashboard:
     pullPolicy: IfNotPresent
 
     ## @param image.tag image tag (immutable tags are recommended)
-    tag: "v2.7.0"
+    tag: "v2.9.0"
 
   ## @param imagePullSecrets image pull secrets
   imagePullSecrets: []

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -586,7 +586,7 @@ dashboard:
     pullPolicy: IfNotPresent
 
     ## @param image.tag image tag (immutable tags are recommended)
-    tag: "2.7.0"
+    tag: "v2.7.0"
 
   ## @param imagePullSecrets image pull secrets
   imagePullSecrets: []


### PR DESCRIPTION
The image in Docker hub is tagged with `v2.7.0`, not `2.7.0`: 

https://hub.docker.com/layers/netbirdio/dashboard/v2.7.0/images/sha256-bfee9630cb214161a21fc9129c67e5350258bc9867d7d67a60aa6650b9521be8

Additionally, the Helm template condition incorrectly renders `command` even when no `args` are specified. Causing an error:

```
/bin/sh: -c requires an argument
```
