### PR TITLE
Enable separate ports for services and containers

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -3,6 +3,6 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 1.5.6
+version: 1.6.0
 appVersion: "0.36.3"
 icon: https://images.crunchbase.com/image/upload/c_pad,h_256,w_256,f_auto,q_auto:eco,dpr_1/kuu5tm1wt09ztp6ctlag

--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -3,6 +3,6 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 1.5.5
+version: 1.5.6
 appVersion: "0.36.3"
 icon: https://images.crunchbase.com/image/upload/c_pad,h_256,w_256,f_auto,q_auto:eco,dpr_1/kuu5tm1wt09ztp6ctlag

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -1,6 +1,6 @@
 # netbird
 
-![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.3](https://img.shields.io/badge/AppVersion-0.36.3-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.3](https://img.shields.io/badge/AppVersion-0.36.3-informational?style=flat-square)
 
 # NetBird Helm Chart
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -1,6 +1,6 @@
 # netbird
 
-![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.3](https://img.shields.io/badge/AppVersion-0.36.3-informational?style=flat-square)
+![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.3](https://img.shields.io/badge/AppVersion-0.36.3-informational?style=flat-square)
 
 # NetBird Helm Chart
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -74,6 +74,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | dashboard.resources | object | `{}` |  |
 | dashboard.securityContext | object | `{}` |  |
 | dashboard.service.name | string | `"http"` |  |
+| dashboard.service.containerOort | int | `80` |  |
 | dashboard.service.port | int | `80` |  |
 | dashboard.service.type | string | `"ClusterIP"` |  |
 | dashboard.serviceAccount.annotations | object | `{}` |  |
@@ -137,9 +138,11 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | management.securityContext | object | `{}` |  |
 | management.useBackwardsGrpcService | bool | `false` |  |
 | management.service.name | string | `"http"` |  |
+| management.service.containerPort | int | `80` |  |
 | management.service.port | int | `80` |  |
 | management.service.type | string | `"ClusterIP"` |  |
 | management.serviceGrpc.name | string | `"http"` |  |
+| management.serviceGrpc.containerPort | int | `33073` |  |
 | management.serviceGrpc.port | int | `33073` |  |
 | management.serviceGrpc.type | string | `"ClusterIP"` |  |
 | management.serviceAccount.annotations | object | `{}` |  |
@@ -178,6 +181,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | relay.resources | object | `{}` |  |
 | relay.securityContext | object | `{}` |  |
 | relay.service.name | string | `"http"` |  |
+| relay.service.containerPort | int | `33080` |  |
 | relay.service.port | int | `33080` |  |
 | relay.service.type | string | `"ClusterIP"` |  |
 | relay.serviceAccount.annotations | object | `{}` |  |
@@ -215,6 +219,7 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | signal.resources | object | `{}` |  |
 | signal.securityContext | object | `{}` |  |
 | signal.service.name | string | `"grpc"` |  |
+| signal.service.containerPort | int | `80` |  |
 | signal.service.port | int | `80` |  |
 | signal.service.type | string | `"ClusterIP"` |  |
 | signal.serviceAccount.annotations | object | `{}` |  |

--- a/charts/netbird/templates/dashboard-deployment.yaml
+++ b/charts/netbird/templates/dashboard-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           {{- end }}
           ports:
             - name: {{ .Values.dashboard.service.name }}
-              containerPort: {{ .Values.dashboard.service.port }}
+              containerPort: {{ .Values.dashboard.service.containerPort | default .Values.dashboard.service.port }}
               protocol: TCP
           {{- if .Values.dashboard.livenessProbe }}
             {{- with .Values.dashboard.livenessProbe }}

--- a/charts/netbird/templates/dashboard-deployment.yaml
+++ b/charts/netbird/templates/dashboard-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           {{- end }}
           ports:
             - name: {{ .Values.dashboard.service.name }}
-              containerPort: {{ .Values.dashboard.service.containerPort | default .Values.dashboard.service.port }}
+              containerPort: {{ .Values.dashboard.service.containerPort }}
               protocol: TCP
           {{- if .Values.dashboard.livenessProbe }}
             {{- with .Values.dashboard.livenessProbe }}

--- a/charts/netbird/templates/management-deployment.yaml
+++ b/charts/netbird/templates/management-deployment.yaml
@@ -69,10 +69,10 @@ spec:
           {{- end }}
           ports:
             - name: {{ .Values.management.service.name }}
-              containerPort: {{ .Values.management.service.port }}
+              containerPort: {{ .Values.management.service.containerPort | default .Values.management.service.port }}
               protocol: TCP
             - name: {{ .Values.management.serviceGrpc.name }}
-              containerPort: {{ .Values.management.serviceGrpc.port }}
+              containerPort: {{ .Values.management.serviceGrpc.containerPort | default .Values.management.serviceGrpc.port }}
               protocol: TCP
           {{- if .Values.management.livenessProbe }}
             {{- with .Values.management.livenessProbe }}

--- a/charts/netbird/templates/management-deployment.yaml
+++ b/charts/netbird/templates/management-deployment.yaml
@@ -69,10 +69,10 @@ spec:
           {{- end }}
           ports:
             - name: {{ .Values.management.service.name }}
-              containerPort: {{ .Values.management.service.containerPort }}
+              containerPort: {{ .Values.management.containerport }}
               protocol: TCP
             - name: {{ .Values.management.serviceGrpc.name }}
-              containerPort: {{ .Values.management.serviceGrpc.containerPort }}
+              containerPort: {{ .Values.management.gprcContainerport }}
               protocol: TCP
           {{- if .Values.management.livenessProbe }}
             {{- with .Values.management.livenessProbe }}

--- a/charts/netbird/templates/management-deployment.yaml
+++ b/charts/netbird/templates/management-deployment.yaml
@@ -69,10 +69,10 @@ spec:
           {{- end }}
           ports:
             - name: {{ .Values.management.service.name }}
-              containerPort: {{ .Values.management.service.containerPort | default .Values.management.service.port }}
+              containerPort: {{ .Values.management.service.containerPort }}
               protocol: TCP
             - name: {{ .Values.management.serviceGrpc.name }}
-              containerPort: {{ .Values.management.serviceGrpc.containerPort | default .Values.management.serviceGrpc.port }}
+              containerPort: {{ .Values.management.serviceGrpc.containerPort }}
               protocol: TCP
           {{- if .Values.management.livenessProbe }}
             {{- with .Values.management.livenessProbe }}

--- a/charts/netbird/templates/relay-deployment.yaml
+++ b/charts/netbird/templates/relay-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.relay.image.pullPolicy }}
           ports:
             - name: {{ .Values.relay.service.name }}
-              containerPort: {{ .Values.relay.service.containerPort | default .Values.relay.service.port }}
+              containerPort: {{ .Values.relay.service.containerPort }}
               protocol: TCP
           {{- if .Values.relay.livenessProbe }}
             {{- with .Values.relay.livenessProbe }}

--- a/charts/netbird/templates/relay-deployment.yaml
+++ b/charts/netbird/templates/relay-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.relay.image.pullPolicy }}
           ports:
             - name: {{ .Values.relay.service.name }}
-              containerPort: {{ .Values.relay.service.port }}
+              containerPort: {{ .Values.relay.service.containerPort | default .Values.relay.service.port }}
               protocol: TCP
           {{- if .Values.relay.livenessProbe }}
             {{- with .Values.relay.livenessProbe }}

--- a/charts/netbird/templates/signal-deployment.yaml
+++ b/charts/netbird/templates/signal-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - "console"
           ports:
             - name: {{ .Values.signal.service.name }}
-              containerPort: {{ .Values.signal.service.port }}
+              containerPort: {{ .Values.signal.service.containerPort | default .Values.signal.service.port }}
               protocol: TCP
           {{- if .Values.signal.livenessProbe }}
             {{- with .Values.signal.livenessProbe }}

--- a/charts/netbird/templates/signal-deployment.yaml
+++ b/charts/netbird/templates/signal-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             - "console"
           ports:
             - name: {{ .Values.signal.service.name }}
-              containerPort: {{ .Values.signal.service.containerPort | default .Values.signal.service.port }}
+              containerPort: {{ .Values.signal.service.containerPort }}
               protocol: TCP
           {{- if .Values.signal.livenessProbe }}
             {{- with .Values.signal.livenessProbe }}

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -118,6 +118,10 @@ management:
     ##
     type: ClusterIP
 
+    ## @param management.service.containerPort Container port for the management service.
+    ##
+    containerPort: 80
+
     ## @param management.service.port Port for the management service.
     ##
     port: 80
@@ -130,6 +134,10 @@ management:
     ## @param management.serviceGrpc.type Service type for the management component.
     ##
     type: ClusterIP
+
+    ## @param management.serviceGrpc.containerPort Container port for the management service.
+    ##
+    containerPort: 33073
 
     ## @param management.serviceGrpc.port Port for the management service.
     ##
@@ -330,6 +338,9 @@ signal:
     ##
     type: ClusterIP
     name: grpc
+    ## @param signal.service.containerPort Container port for the signal service.
+    ##
+    containerPort: 80
     ## @param signal.service.port Port for the signal service.
     ##
     port: 80
@@ -489,6 +500,10 @@ relay:
     ##
     type: ClusterIP
 
+    ## @param relay.service.containerPort Container port for the relay service.
+    ##
+    containerPort: 33080
+
     ## @param relay.service.port Port for the relay service.
     ##
     port: 33080
@@ -631,6 +646,9 @@ dashboard:
   service:
     ## @param dashboard.service.type
     type: ClusterIP
+
+    ## @param dashboard.service.containerPort
+    containerPort: 80
 
     ## @param dashboard.service.port
     port: 80


### PR DESCRIPTION
Currently, if service ports are changed, at least some pods fail their liveness probes because the container ports are using the service port numbers. 

In order to change the service ports, it would also be necessary to reconfigure the applications to listen on the same ports. 

Since Kubernetes allows for abstracting container ports using services, there needs to be a way to specify them separately. 

A typical use case is where Kubernetes node-to-node traffic is restricted by firewall to allow only registered (1024-49151) or ephemeral (49152-65535) ports. In this case, it is necessary to have the services listen on ports 1024 or above.  