### PR TITLE
Add support for Storage Classes and pre-provisioned PVs

### DIFF
--- a/charts/netbird/Chart.yaml
+++ b/charts/netbird/Chart.yaml
@@ -3,6 +3,6 @@ apiVersion: v2
 name: netbird
 description: NetBird VPN management platform
 type: application
-version: 1.6.0
+version: 1.6.1
 appVersion: "0.36.5"
 icon: https://images.crunchbase.com/image/upload/c_pad,h_256,w_256,f_auto,q_auto:eco,dpr_1/kuu5tm1wt09ztp6ctlag

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -1,6 +1,6 @@
 # netbird
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.5](https://img.shields.io/badge/AppVersion-0.36.5-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.36.5](https://img.shields.io/badge/AppVersion-0.36.5-informational?style=flat-square)
 
 # NetBird Helm Chart
 

--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -124,6 +124,8 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | management.persistentVolume.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | management.persistentVolume.enabled | bool | `true` |  |
 | management.persistentVolume.size | string | `"10Mi"` |  |
+| management.persistentVolume.storageClass | string | `null` |  |
+| management.persistentVolume.existingPVName | string | `""` |  |
 | management.podAnnotations | object | `{}` |  |
 | management.podCommand.args[0] | string | `"--port=80"` |  |
 | management.podCommand.args[1] | string | `"--log-file=console"` |  |

--- a/charts/netbird/templates/management-pvc.yaml
+++ b/charts/netbird/templates/management-pvc.yaml
@@ -10,6 +10,12 @@ metadata:
 spec:
   accessModes:
     {{ toYaml .Values.management.persistentVolume.accessModes }}
+  {{- if or .Values.management.persistentVolume.storageClass (eq .Values.management.persistentVolume.storageClass "") }}
+  storageClassName: "{{ .Values.management.persistentVolume.storageClass }}"
+  {{- end }}
+  {{- if .Values.management.persistentVolume.existingPVName }}
+  volumeName: "{{ .Values.management.persistentVolume.existingPVName }}"
+  {{- end }}
   resources:
     requests:
       storage: "{{ .Values.management.persistentVolume.size }}"

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -254,6 +254,14 @@ management:
     ##
     size: 10Mi
 
+    ## @param management.persistentVolume.storageClass Storage Class of the persistent volume.
+    ##
+    storageClass: null
+
+    ## @param management.persistentVolume.existingPVName The name of an existing persistent volume which should be claimed and used for the management pod.
+    ##
+    existingPVName: ""
+
   ## @param management.dnsDomain DNS domain for the management component.
   ##
   dnsDomain: netbird.selfhosted


### PR DESCRIPTION
## Add support for Storage Classes and pre-provisioned PVs

This PR adds support for two features for the Netbird Management pod PVC:

- Specifying a storage class
- Specifying an existing Persistent Volume

### Storage Class

Users may wish to use a non-default Storage Class.

- Added value `.Values.management.persistentVolume.storageClass` to populate the `.spec.storageClassName` field in the PVC manifest
- The implementation preserves the underlying behaviour of the `storageClassName` field, i.e. [empty string (`""`) has subtly different behaviour to no value (`null`)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1).
- The implementation also preserves the previous default behaviour of the chart - setting no value for the `storageClassName` field, thus the change is non-breaking

### Pre-existing Persistent Volumes

Some users may wish to provision volumes separately from the chart (i.e. [static provisioning](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#static)), for example when migrating configuration data between environments or storage types.

- Added value `.Values.management.persistentVolume.existingPVName` to populate the `.spec.volumeName` field in the PVC manifest