### PR TITLE
chore(management-deployment): allow to configure the strategy

### DIFF
--- a/charts/netbird/README.md
+++ b/charts/netbird/README.md
@@ -156,6 +156,9 @@ The following table lists the configurable parameters of the NetBird Helm chart 
 | management.serviceGrpc.name | string | `"grpc"` |  |
 | management.serviceGrpc.port | int | `33073` |  |
 | management.serviceGrpc.type | string | `"ClusterIP"` |  |
+| management.strategy.type | string | `"RollingUpdate"` |  |
+| management.strategy.rollingUpdate.maxSurge | string | `"25%"` |  |
+| management.strategy.rollingUpdate.maxUnavailable | string | `"25%"` |  |
 | management.tolerations | list | `[]` |  |
 | management.useBackwardsGrpcService | bool | `false` |  |
 | metrics.serviceMonitor.annotations | object | `{}` |  |

--- a/charts/netbird/templates/management-deployment.yaml
+++ b/charts/netbird/templates/management-deployment.yaml
@@ -16,6 +16,15 @@ spec:
   selector:
     matchLabels:
       {{- include "netbird.management.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.management.strategy.type }}
+    {{- if eq .Values.management.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      {{- if .Values.management.strategy.rollingUpdate }}
+      maxSurge: {{ .Values.management.strategy.rollingUpdate.maxSurge | default "25%" }}
+      maxUnavailable: {{ .Values.management.strategy.rollingUpdate.maxUnavailable | default "25%" }}
+      {{- end }}
+    {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/netbird/values.yaml
+++ b/charts/netbird/values.yaml
@@ -39,6 +39,14 @@ management:
   ##
   replicaCount: 1
 
+  ## @param management.strategy Deployment strategy for the management component.
+  ##
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+
   ## @param management.env Environment variables for the management pod.
   ##
   env: {}


### PR DESCRIPTION
Hello,

This PR addresses an issue encountered when using a `ReadWriteOnce` PersistentVolumeClaim for the management component. The default `RollingUpdate` strategy in the Deployment causes the new pod to enter the `ContainerCreating` state indefinitely, as the volume cannot be mounted simultaneously by multiple pods.

This change introduces a configurable deployment strategy for the management component, allowing users to switch to Recreate or another suitable strategy to avoid volume mounting conflicts.

